### PR TITLE
fix: conventional commit issue-id

### DIFF
--- a/pipeline/commit_checker.py
+++ b/pipeline/commit_checker.py
@@ -83,7 +83,7 @@ def get_commit_message(sha: str) -> str:
 
 
 def validate_branch_name(branch: str) -> str:
-    pattern = rf"^({'|'.join(ALLOWED_TYPES)})/[0-9]+/[a-z0-9]+([._-][a-z0-9]+)*$"
+    pattern = rf"^({'|'.join(ALLOWED_TYPES)})/gh-[0-9]+/[a-z0-9]+([._-][a-z0-9]+)*$"
     match = re.match(pattern, branch)
 
     if not match:


### PR DESCRIPTION
This PR fix the issue with conventional commits checker workflow when we provide wrong branch name.

Issue-ID: gh-11