### PR TITLE
feat: add auto-assign workflow

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,16 @@
+name: Auto-assign PR author
+
+on:
+  pull_request:
+    types: [ opened ]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Assign PR author
+      uses: actions-ecosystem/action-add-assignees@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        assignees: ${{ github.actor }}


### PR DESCRIPTION
This PR introduces workflow that will auto-assign PR to the author. Thanks to that it will be easier to track which PR was done by specific developer.

Issue-ID: gh-35