### PR TITLE
feat: add platform terraform module

### DIFF
--- a/.github/workflows/terraform_platform.yml
+++ b/.github/workflows/terraform_platform.yml
@@ -1,0 +1,56 @@
+name: Terraform Platform
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply terraform changes (default: false)"
+        required: true
+        default: "false"
+        type: choice
+        options:
+        - "false"
+        - "true"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform-platform:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: infra/terraform/platform
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: 1.14.6
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ vars.AWS_PLATFORM_ROLE_ARN }}
+        aws-region: eu-central-1
+
+    - name: Terraform Format Check
+      run: terraform fmt -check
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Validate
+      run: terraform validate
+
+    - name: Terraform Plan
+      run: terraform plan -out=tfplan.binary
+
+    - name: Terraform Apply
+      if: ${{ github.event.inputs.apply == 'true' }}
+      run: terraform apply -auto-approve tfplan.binary

--- a/infra/terraform/core/README.md
+++ b/infra/terraform/core/README.md
@@ -187,3 +187,4 @@ Current naming convention:
 Generated state bucket:
 
 - `boardgames-dev-tfstate`
+

--- a/infra/terraform/platform/.terraform.lock.hcl
+++ b/infra/terraform/platform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.41.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:iFwjmQtc0tIkSpB1KL+LcqLfuR6KYIGs49ea+LdVXXQ=",
+    "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
+    "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
+    "zh:196f81d97ea2951d2c6667709445d7c36b5fd8603890c774495806b4da0743aa",
+    "zh:1ba36118b0146e5c3603020509b34d09e693db50ec29f9be5badc9f2a4fd95b8",
+    "zh:4253c2f6066ce279e5ce48849c78fc193f222dc42a929e6876b9563ed5c23fcf",
+    "zh:457ed8609680338dbcb9809e263638a530c06ba43208af9e660803133dc5e1e6",
+    "zh:4e8de5f3fcc3e3f41b6703ad4c0fa62175d0c29afcf56ac82eb16c604bb6dafa",
+    "zh:583ae622cfe4633fabca071ded738e9ef3398d9e9916cb26350aad28068462c5",
+    "zh:5b8bf11070c13e21a0fef05713a25be0392c7d064bd2199c2f99939cc345e8c5",
+    "zh:6aa7ae41d4fff4e95cedcbeaa143b2af9ad3e3a4b40208801b701d77a738b2c7",
+    "zh:8143670bca48af3b873b0db83443dbdcb868442f1e789ffba356d6adf4dbd7b9",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c22951cf0a4b169607ea066717dd499f46221af035903497b97f24590fb79d2c",
+    "zh:dbd9cd975206a41a9c12006d3a30c77b95c0e660fcba2cc3bb0ee5779431c107",
+    "zh:e6ea2e0f142001b7f2229e8d39eb7f8037084723861be9d53478005196cd7f9e",
+  ]
+}

--- a/infra/terraform/platform/README.md
+++ b/infra/terraform/platform/README.md
@@ -1,0 +1,129 @@
+# Terraform Platform Infrastructure
+
+This directory contains the Terraform configuration responsible for provisioning
+the platform IAM role used by GitHub Actions to manage application infrastructure
+(VPC, EKS, ECR, CloudWatch and other future modules).
+
+## Purpose
+
+The `platform` layer creates and manages:
+
+- IAM managed policy granting the platform GitHub Actions role access to Terraform state
+- Policy attachment to the `github-actions-boardgames-dev-platform` role
+
+This layer is intentionally minimal at this stage. Permissions will be extended
+as new infrastructure modules are added (networking, EKS, ECR, CloudWatch).
+
+## Why this exists
+
+The `core` module manages Terraform state backend. Everything above it — VPC, EKS,
+ECR, CloudWatch — is provisioned by a separate `platform` role. This separation ensures
+that a failure or misconfiguration in platform workflows cannot affect the state backend.
+
+See `infra/terraform/core/` for the bootstrap problem explanation and two-phase setup pattern.
+
+## Structure
+
+```
+platform/
+├── main.tf                                     - IAM policy and role attachment
+├── variables.tf                                - input variables
+├── locals.tf                                   - naming and tagging logic
+├── outputs.tf                                  - exposed outputs
+├── providers.tf                                - AWS provider configuration
+├── versions.tf                                 - Terraform and provider constraints
+├── policies/
+│   └── tfstate-access.json.tftpl               - least-privilege tfstate policy (platform + core read)
+└── bootstrap/
+    ├── platform-bootstrap-policy.json.tftpl    - permissions for Terraform to manage this module
+    ├── platform-assume-role-policy.json.tftpl  - OIDC trust policy (who can assume the role)
+    └── apply.sh                                - one-time bootstrap script
+```
+
+## How terraform_remote_state works here
+
+This module reads outputs from the `core` module using `data "terraform_remote_state"`:
+
+```hcl
+data "terraform_remote_state" "core" {
+  backend = "s3"
+  config = {
+    bucket = "boardgames-dev-tfstate"
+    key    = "core/dev/terraform.tfstate"
+    region = "eu-central-1"
+  }
+}
+```
+
+Instead of hardcoding the S3 bucket ARN, the platform module reads it directly from
+core's Terraform state. This creates an explicit dependency between modules — if core
+state does not exist in S3, platform `plan` will fail. The platform role therefore needs
+`s3:GetObject` on the core state file, included in both `platform-bootstrap-policy.json.tftpl`
+and `policies/tfstate-access.json.tftpl`.
+
+This is why core state must be migrated to S3 before platform can run (see core README,
+Bootstrap section). Once core state is in S3, platform works without any manual steps.
+
+In production, SSM Parameter Store is a common alternative to `terraform_remote_state`
+as it avoids tight coupling between modules — core writes outputs to SSM, other modules
+read from SSM without knowing where the state lives.
+
+## Local AWS credentials setup
+
+See `infra/terraform/core/README.md` for AWS CLI v2 installation and SSO profile setup.
+The same profile (`boardgames-dev-admin`) is used for all Terraform modules.
+
+## Bootstrap
+
+**Phase 0 — Bootstrap (run once, manually, with admin credentials):**
+
+```bash
+export AWS_PROFILE=boardgames-dev-admin
+./bootstrap/apply.sh
+```
+
+This script uses `envsubst` to render the JSON templates and applies them via AWS CLI:
+- creates the `github-actions-boardgames-dev-platform` IAM role if it does not exist
+- if the role already exists, updates its assume role policy (idempotent — safe to re-run)
+- attaches `boardgames-dev-platform-bootstrap` inline policy (permissions to manage this module's resources)
+
+The script is safe to re-run at any time — role creation is skipped if the role already exists,
+and both `update-assume-role-policy` and `put-role-policy` are idempotent AWS CLI operations.
+
+**Phase 1 — Terraform (runs automatically via GitHub Actions after every push):**
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+The `terraform_platform.yml` workflow handles this automatically.
+
+## Usage
+
+### Local run
+
+```bash
+export AWS_PROFILE=boardgames-dev-admin
+terraform init
+terraform plan
+terraform apply
+```
+
+### Important notes
+
+- Do NOT store application infrastructure here (VPC, EKS, ECR etc.) — those go in `modules/` and `environments/`
+- Bootstrap policy will be extended as new modules are added
+- `bootstrap/` files are not referenced by Terraform — they exist for documentation and re-provisioning
+
+## Naming
+
+Current naming convention:
+
+- project: `boardgames`
+- environment: `dev`
+
+Generated resources:
+
+- IAM policy: `boardgames-dev-github-platform-tfstate-access`

--- a/infra/terraform/platform/bootstrap/apply.sh
+++ b/infra/terraform/platform/bootstrap/apply.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run once with admin AWS credentials to bootstrap the platform IAM role.
+# Usage:
+#   export AWS_PROFILE=boardgames-dev-admin
+#   ./bootstrap/apply.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+account_id=$(aws sts get-caller-identity --query Account --output text)
+bucket_name="boardgames-dev-tfstate"
+environment="dev"
+platform_role_name="github-actions-boardgames-dev-platform"
+tfstate_policy_name="boardgames-dev-github-platform-tfstate-access"
+github_repo="gl-devops-team/board-games-library"
+
+export account_id bucket_name environment platform_role_name tfstate_policy_name github_repo
+
+envsubst < "${SCRIPT_DIR}/platform-assume-role-policy.json.tftpl" > /tmp/assume-role-policy.json
+role_description="GitHub Actions OIDC role for Terraform platform module - app infrastructure"
+
+if aws iam get-role --role-name "${platform_role_name}" > /dev/null 2>&1; then
+  echo "Role ${platform_role_name} already exists, skipping creation"
+  echo "Updating assume role policy for role: ${platform_role_name}"
+  aws iam update-assume-role-policy \
+    --role-name "${platform_role_name}" \
+    --policy-document file:///tmp/assume-role-policy.json
+  aws iam update-role \
+    --role-name "${platform_role_name}" \
+    --description "${role_description}"
+else
+  echo "Creating platform IAM role: ${platform_role_name}"
+  aws iam create-role \
+    --role-name "${platform_role_name}" \
+    --description "${role_description}" \
+    --assume-role-policy-document file:///tmp/assume-role-policy.json
+fi
+
+echo "Applying bootstrap policy to role: ${platform_role_name}"
+envsubst < "${SCRIPT_DIR}/platform-bootstrap-policy.json.tftpl" > /tmp/bootstrap-policy.json
+aws iam put-role-policy \
+  --role-name "${platform_role_name}" \
+  --policy-name "boardgames-dev-platform-bootstrap" \
+  --policy-document file:///tmp/bootstrap-policy.json
+
+echo "Bootstrap complete. Run 'terraform apply' in infra/terraform/platform/ next."

--- a/infra/terraform/platform/bootstrap/platform-assume-role-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-assume-role-policy.json.tftpl
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:${github_repo}:*"
+        }
+      }
+    }
+  ]
+}

--- a/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
@@ -1,0 +1,62 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ReadCoreState",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::${bucket_name}/core/${environment}/terraform.tfstate"
+    },
+    {
+      "Sid": "ManagePlatformState",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}/platform/${environment}/terraform.tfstate",
+        "arn:aws:s3:::${bucket_name}/platform/${environment}/terraform.tfstate.tflock"
+      ]
+    },
+    {
+      "Sid": "ListStateBucket",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::${bucket_name}"
+    },
+    {
+      "Sid": "ReadPlatformRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:ListAttachedRolePolicies"
+      ],
+      "Resource": "arn:aws:iam::${account_id}:role/${platform_role_name}"
+    },
+    {
+      "Sid": "ManageTfstatePolicy",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreatePolicy",
+        "iam:GetPolicy",
+        "iam:GetPolicyVersion",
+        "iam:ListPolicyVersions",
+        "iam:CreatePolicyVersion",
+        "iam:DeletePolicyVersion",
+        "iam:TagPolicy"
+      ],
+      "Resource": "arn:aws:iam::${account_id}:policy/${tfstate_policy_name}"
+    },
+    {
+      "Sid": "AttachPolicyToRole",
+      "Effect": "Allow",
+      "Action": [
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy"
+      ],
+      "Resource": "arn:aws:iam::${account_id}:role/${platform_role_name}"
+    }
+  ]
+}

--- a/infra/terraform/platform/locals.tf
+++ b/infra/terraform/platform/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+
+  tfstate_key = "platform/${var.environment}/terraform.tfstate"
+
+  github_platform_role_name = "github-actions-${local.name_prefix}-${var.component}"
+
+  common_tags = {
+    Project     = var.project
+    Environment = var.environment
+    Component   = var.component
+    ManagedBy   = "Terraform"
+  }
+}

--- a/infra/terraform/platform/main.tf
+++ b/infra/terraform/platform/main.tf
@@ -1,0 +1,27 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+  config = {
+    bucket = "${local.name_prefix}-tfstate"
+    key    = "core/${var.environment}/terraform.tfstate"
+    region = var.aws_region
+  }
+}
+
+data "aws_iam_role" "github_platform_role" {
+  name = local.github_platform_role_name
+}
+
+resource "aws_iam_policy" "github_platform_tfstate_access" {
+  name        = "${local.name_prefix}-github-platform-tfstate-access"
+  description = "Least-privilege access for GitHub Terraform platform workflow to Terraform state bucket"
+  policy = templatefile("${path.module}/policies/tfstate-access.json.tftpl", {
+    bucket_arn  = data.terraform_remote_state.core.outputs.tfstate_bucket_arn
+    tfstate_key = local.tfstate_key
+    environment = var.environment
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_platform_tfstate_access" {
+  role       = data.aws_iam_role.github_platform_role.name
+  policy_arn = aws_iam_policy.github_platform_tfstate_access.arn
+}

--- a/infra/terraform/platform/outputs.tf
+++ b/infra/terraform/platform/outputs.tf
@@ -1,0 +1,9 @@
+output "tfstate_bucket_name" {
+  description = "Name of the S3 bucket used for storing Terraform state"
+  value       = data.terraform_remote_state.core.outputs.tfstate_bucket_name
+}
+
+output "github_platform_tfstate_policy_arn" {
+  description = "ARN of the IAM policy granting GitHub platform workflow access to Terraform state bucket"
+  value       = aws_iam_policy.github_platform_tfstate_access.arn
+}

--- a/infra/terraform/platform/policies/tfstate-access.json.tftpl
+++ b/infra/terraform/platform/policies/tfstate-access.json.tftpl
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListStateBucket",
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "${bucket_arn}",
+      "Condition": {
+        "StringEquals": {
+          "s3:prefix": ["${tfstate_key}", "${tfstate_key}.tflock"]
+        }
+      }
+    },
+    {
+      "Sid": "ReadWriteStateFile",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": "${bucket_arn}/${tfstate_key}"
+    },
+    {
+      "Sid": "ReadWriteDeleteLockFile",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": "${bucket_arn}/${tfstate_key}.tflock"
+    },
+    {
+      "Sid": "ReadCoreStateFile",
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "${bucket_arn}/core/${environment}/terraform.tfstate"
+    }
+  ]
+}

--- a/infra/terraform/platform/providers.tf
+++ b/infra/terraform/platform/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/platform/variables.tf
+++ b/infra/terraform/platform/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "AWS region used for platform infrastructure resources"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "project" {
+  description = "Project name used for tagging and naming resources"
+  type        = string
+  default     = "boardgames"
+}
+
+variable "environment" {
+  description = "Environment name used for tagging and naming resources"
+  type        = string
+  default     = "dev"
+}
+
+variable "component" {
+  description = "Component name used for tagging and naming resources"
+  type        = string
+  default     = "platform"
+}

--- a/infra/terraform/platform/versions.tf
+++ b/infra/terraform/platform/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">=1.9.0, <2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+
+  backend "s3" {
+    bucket = "boardgames-dev-tfstate"
+    key    = "platform/dev/terraform.tfstate"
+    region = "eu-central-1"
+  }
+}


### PR DESCRIPTION
Introduces platform module with IAM managed policy for GitHub Actions OIDC role. Reads core state via terraform_remote_state to get S3 bucket ARN. Includes bootstrap script for one-time role setup and GitHub Actions workflow for automated plan/apply.

Issue-ID: gh-67