### PR TITLE
feat: add ECR Terraform module for backend and frontend container images

### DIFF
--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -24,7 +24,7 @@ environments/dev/
 State is stored in S3:
 
 ```
-s3://boardgames-dev-tfstate/networking/dev/terraform.tfstate
+s3://boardgames-dev-tfstate/env/dev/terraform.tfstate
 ```
 
 All module resources accumulate in the same state file — Terraform handles dependency

--- a/infra/terraform/environments/dev/README.md
+++ b/infra/terraform/environments/dev/README.md
@@ -14,7 +14,7 @@ definitions only — they have no backend and cannot be run directly.
 
 ```
 environments/dev/
-├── main.tf       - module calls (networking, and future: ecr, eks...)
+├── main.tf       - module calls (networking, ecr, and future: eks...)
 ├── providers.tf  - AWS provider for eu-central-1
 └── versions.tf   - Terraform version constraints + S3 backend configuration
 ```
@@ -27,8 +27,8 @@ State is stored in S3:
 s3://boardgames-dev-tfstate/networking/dev/terraform.tfstate
 ```
 
-As more modules are added, their resources accumulate in the same state file — Terraform
-handles dependency ordering automatically based on output references between modules.
+All module resources accumulate in the same state file — Terraform handles dependency
+ordering automatically based on output references between modules.
 
 ## Prerequisites
 
@@ -63,4 +63,5 @@ The workflow uses the `github-actions-boardgames-dev-platform` role (via OIDC).
 ## Cost note
 
 NAT Gateways (~$32/month each × 2) are the main cost driver in this environment.
+ECR repositories have no base cost — you pay only for storage and data transfer.
 Run `terraform destroy` when the environment is not needed to avoid ongoing charges.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -4,3 +4,10 @@ module "networking" {
   project     = "boardgames"
   environment = "dev"
 }
+
+module "ecr" {
+  source = "../../modules/ecr"
+
+  project     = "boardgames"
+  environment = "dev"
+}

--- a/infra/terraform/environments/dev/versions.tf
+++ b/infra/terraform/environments/dev/versions.tf
@@ -10,7 +10,7 @@ terraform {
 
   backend "s3" {
     bucket = "boardgames-dev-tfstate"
-    key    = "networking/dev/terraform.tfstate"
+    key    = "env/dev/terraform.tfstate"
     region = "eu-central-1"
   }
 }

--- a/infra/terraform/modules/ecr/README.md
+++ b/infra/terraform/modules/ecr/README.md
@@ -41,7 +41,7 @@ Total: **6 resources**
 Two rules per repository:
 
 1. **Untagged images** — expired after 1 day (build artifacts without a release tag)
-2. **Tagged images** — keep the last `max_image_count` (default 10) images prefixed with `v`
+2. **Tagged images** — keep the last `max_image_count` (default 10) images regardless of tag
 
 ## Repository policy
 

--- a/infra/terraform/modules/ecr/README.md
+++ b/infra/terraform/modules/ecr/README.md
@@ -1,0 +1,69 @@
+# Terraform ECR Module
+
+This directory contains the reusable Terraform module for provisioning AWS Elastic
+Container Registry repositories. It is not a root module — it is called from
+`environments/dev/` and does not define a backend or run `terraform init` directly.
+
+## Purpose
+
+The `ecr` module creates private container image repositories for the application's
+Docker images. ECR is provisioned before EKS — nodes need to pull images during
+deployment. Using ECR over Docker Hub eliminates rate limiting, keeps images in the
+same AWS account/region (faster pulls, no egress costs), and integrates natively
+with IAM for access control.
+
+## Structure
+
+```
+modules/ecr/
+├── main.tf       - ECR repositories, lifecycle policies, repository policies
+├── locals.tf     - name prefix, common tags
+├── variables.tf  - input variables (aws_region, project, environment, component, image_names, max_image_count)
+├── outputs.tf    - repository_urls, repository_arns
+├── providers.tf  - AWS provider with default tags
+└── versions.tf   - Terraform and provider version constraints (no backend block)
+```
+
+## Resources created
+
+| Resource | Count | Notes |
+|---|---|---|
+| `aws_ecr_repository` | 2 | backend, frontend — immutable tags, scan on push |
+| `aws_ecr_lifecycle_policy` | 2 | Expire untagged after 1 day, keep last N tagged |
+| `aws_ecr_repository_policy` | 2 | Scoped to `boardgames-dev-*` IAM roles |
+
+Total: **6 resources**
+
+## Lifecycle policy
+
+Two rules per repository:
+
+1. **Untagged images** — expired after 1 day (build artifacts without a release tag)
+2. **Tagged images** — keep the last `max_image_count` (default 10) images prefixed with `v`
+
+## Repository policy
+
+Access is scoped to IAM roles matching `boardgames-dev-*` in the same account.
+This covers the platform GitHub Actions role and future EKS node roles without
+granting blanket access.
+
+## Usage
+
+This module is not run directly. It is called from `environments/dev/main.tf`:
+
+```hcl
+module "ecr" {
+  source      = "../../modules/ecr"
+  project     = "boardgames"
+  environment = "dev"
+}
+```
+
+Run Terraform from `environments/dev/`, not from this directory.
+
+## Outputs
+
+Downstream modules (EKS, CI/CD) consume outputs from this module:
+
+- `repository_urls` — map of image name → ECR URL (used in Kubernetes manifests and docker push)
+- `repository_arns` — map of image name → ARN (used in IAM policies)

--- a/infra/terraform/modules/ecr/README.md
+++ b/infra/terraform/modules/ecr/README.md
@@ -1,4 +1,4 @@
-# Terraform ECR Module
+  # Terraform ECR Module
 
 This directory contains the reusable Terraform module for provisioning AWS Elastic
 Container Registry repositories. It is not a root module — it is called from
@@ -17,6 +17,8 @@ with IAM for access control.
 ```
 modules/ecr/
 ├── main.tf       - ECR repositories, lifecycle policies, repository policies
+├── policies/
+│   └── repository-access.json.tftpl - IAM policy scoped to boardgames-dev-* roles
 ├── locals.tf     - name prefix, common tags
 ├── variables.tf  - input variables (aws_region, project, environment, component, image_names, max_image_count)
 ├── outputs.tf    - repository_urls, repository_arns

--- a/infra/terraform/modules/ecr/locals.tf
+++ b/infra/terraform/modules/ecr/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+
+  common_tags = {
+    Project     = var.project
+    Environment = var.environment
+    Component   = var.component
+    ManagedBy   = "Terraform"
+  }
+}

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,0 +1,89 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_ecr_repository" "this" {
+  for_each = toset(var.image_names)
+
+  name                 = "${local.name_prefix}/${each.value}"
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Name = "${local.name_prefix}/${each.value}"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each = aws_ecr_repository.this
+
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last ${var.max_image_count} tagged images"
+        selection = {
+          tagStatus   = "tagged"
+          tagPrefixList = ["v"]
+          countType   = "imageCountMoreThan"
+          countNumber = var.max_image_count
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository_policy" "this" {
+  for_each = aws_ecr_repository.this
+
+  repository = each.value.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowPlatformRoles"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeImages",
+          "ecr:ListImages"
+        ]
+        Condition = {
+          ArnLike = {
+            "aws:PrincipalArn" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.name_prefix}-*"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,6 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-resource "aws_ecr_repository" "this" {
+resource "aws_ecr_repository" "app" {
   #checkov:skip=CKV_AWS_136: AES256 server-side encryption is sufficient for dev — KMS adds cost with no practical benefit here
   for_each = toset(var.image_names)
 
@@ -21,8 +21,8 @@ resource "aws_ecr_repository" "this" {
   }
 }
 
-resource "aws_ecr_lifecycle_policy" "this" {
-  for_each = aws_ecr_repository.this
+resource "aws_ecr_lifecycle_policy" "app" {
+  for_each = aws_ecr_repository.app
 
   repository = each.value.name
 
@@ -41,10 +41,9 @@ resource "aws_ecr_lifecycle_policy" "this" {
       },
       {
         rulePriority = 2
-        description  = "Keep last ${var.max_image_count} tagged images"
+        description  = "Keep last ${var.max_image_count} images"
         selection = {
-          tagStatus   = "tagged"
-          tagPrefixList = ["v"]
+          tagStatus   = "any"
           countType   = "imageCountMoreThan"
           countNumber = var.max_image_count
         }
@@ -54,8 +53,8 @@ resource "aws_ecr_lifecycle_policy" "this" {
   })
 }
 
-resource "aws_ecr_repository_policy" "this" {
-  for_each = aws_ecr_repository.this
+resource "aws_ecr_repository_policy" "app" {
+  for_each = aws_ecr_repository.app
 
   repository = each.value.name
 

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,6 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 resource "aws_ecr_repository" "this" {
+  #checkov:skip=CKV_AWS_136: AES256 server-side encryption is sufficient for dev — KMS adds cost with no practical benefit here
   for_each = toset(var.image_names)
 
   name                 = "${local.name_prefix}/${each.value}"

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -59,32 +59,8 @@ resource "aws_ecr_repository_policy" "this" {
 
   repository = each.value.name
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowPlatformRoles"
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
-        }
-        Action = [
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:BatchGetImage",
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:PutImage",
-          "ecr:InitiateLayerUpload",
-          "ecr:UploadLayerPart",
-          "ecr:CompleteLayerUpload",
-          "ecr:DescribeImages",
-          "ecr:ListImages"
-        ]
-        Condition = {
-          ArnLike = {
-            "aws:PrincipalArn" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.name_prefix}-*"
-          }
-        }
-      }
-    ]
+  policy = templatefile("${path.module}/policies/repository-access.json.tftpl", {
+    account_id  = data.aws_caller_identity.current.account_id
+    name_prefix = local.name_prefix
   })
 }

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_urls" {
+  description = "Map of image name to ECR repository URL"
+  value       = { for k, v in aws_ecr_repository.this : k => v.repository_url }
+}
+
+output "repository_arns" {
+  description = "Map of image name to ECR repository ARN"
+  value       = { for k, v in aws_ecr_repository.this : k => v.arn }
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -1,9 +1,9 @@
 output "repository_urls" {
   description = "Map of image name to ECR repository URL"
-  value       = { for k, v in aws_ecr_repository.this : k => v.repository_url }
+  value       = { for k, v in aws_ecr_repository.app : k => v.repository_url }
 }
 
 output "repository_arns" {
   description = "Map of image name to ECR repository ARN"
-  value       = { for k, v in aws_ecr_repository.this : k => v.arn }
+  value       = { for k, v in aws_ecr_repository.app : k => v.arn }
 }

--- a/infra/terraform/modules/ecr/policies/repository-access.json.tftpl
+++ b/infra/terraform/modules/ecr/policies/repository-access.json.tftpl
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPlatformRoles",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:root"
+      },
+      "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:DescribeImages",
+        "ecr:ListImages"
+      ],
+      "Condition": {
+        "ArnLike": {
+          "aws:PrincipalArn": "arn:aws:iam::${account_id}:role/${name_prefix}-*"
+        }
+      }
+    }
+  ]
+}

--- a/infra/terraform/modules/ecr/providers.tf
+++ b/infra/terraform/modules/ecr/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/modules/ecr/variables.tf
+++ b/infra/terraform/modules/ecr/variables.tf
@@ -1,0 +1,35 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "project" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "boardgames"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "dev"
+}
+
+variable "component" {
+  description = "Component name used for tagging"
+  type        = string
+  default     = "ecr"
+}
+
+variable "image_names" {
+  description = "List of application image names to create ECR repositories for"
+  type        = list(string)
+  default     = ["backend", "frontend"]
+}
+
+variable "max_image_count" {
+  description = "Maximum number of tagged images to keep per repository"
+  type        = number
+  default     = 10
+}

--- a/infra/terraform/modules/ecr/versions.tf
+++ b/infra/terraform/modules/ecr/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.9.0, <2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
@@ -18,8 +18,8 @@
       "Resource": [
         "arn:aws:s3:::${bucket_name}/platform/${environment}/terraform.tfstate",
         "arn:aws:s3:::${bucket_name}/platform/${environment}/terraform.tfstate.tflock",
-        "arn:aws:s3:::${bucket_name}/networking/${environment}/terraform.tfstate",
-        "arn:aws:s3:::${bucket_name}/networking/${environment}/terraform.tfstate.tflock"
+        "arn:aws:s3:::${bucket_name}/env/${environment}/terraform.tfstate",
+        "arn:aws:s3:::${bucket_name}/env/${environment}/terraform.tfstate.tflock"
       ]
     },
     {
@@ -128,8 +128,7 @@
       "Sid": "DescribeEcrAuthorization",
       "Effect": "Allow",
       "Action": [
-        "ecr:GetAuthorizationToken",
-        "ecr:DescribeRepositories"
+        "ecr:GetAuthorizationToken"
       ],
       "Resource": "*"
     }

--- a/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
@@ -103,6 +103,35 @@
         "iam:DetachRolePolicy"
       ],
       "Resource": "arn:aws:iam::${account_id}:role/${platform_role_name}"
+    },
+    {
+      "Sid": "ManageEcrRepositories",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreateRepository",
+        "ecr:DeleteRepository",
+        "ecr:DescribeRepositories",
+        "ecr:ListTagsForResource",
+        "ecr:TagResource",
+        "ecr:UntagResource",
+        "ecr:PutLifecyclePolicy",
+        "ecr:GetLifecyclePolicy",
+        "ecr:DeleteLifecyclePolicy",
+        "ecr:SetRepositoryPolicy",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DeleteRepositoryPolicy",
+        "ecr:PutImageScanningConfiguration"
+      ],
+      "Resource": "arn:aws:ecr:eu-central-1:${account_id}:repository/boardgames-${environment}/*"
+    },
+    {
+      "Sid": "DescribeEcrAuthorization",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:DescribeRepositories"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Create infra/terraform/modules/ecr/ with ECR repositories, lifecycle policies (expire untagged, keep last N tagged), and repository policy scoped to boardgames-dev-* IAM roles. Wire module into environments/dev/ and extend platform bootstrap policy with ECR permissions.

Issue-ID: gh-69