### PR TITLE
fix: show only failed Checkov results in CI output

### DIFF
--- a/.github/workflows/checkov_infra.yml
+++ b/.github/workflows/checkov_infra.yml
@@ -45,21 +45,24 @@ jobs:
       run: |
         checkov -d infra/terraform \
           --framework terraform \
-          --compact
+          --compact \
+          --quiet
 
     # 🔹 Dockerfiles (build security)
     - name: Run Checkov on Dockerfiles
       run: |
         checkov -d infra/docker \
           --framework dockerfile \
-          --compact
+          --compact \
+          --quiet
 
     # 🔹 Kubernetes manifests
     - name: Run Checkov on Kubernetes
       run: |
         checkov -d infra/k8s \
           --framework kubernetes \
-          --compact
+          --compact \
+          --quiet
 
   checkov-status:
     needs: checkov-run


### PR DESCRIPTION
Add --quiet flag to all Checkov steps in checkov_infra.yml to suppress passed checks and reduce noise.

Issue-ID: gh-64