### PR TITLE
Fix: Develop commit_checker issue

### DIFF
--- a/pipeline/commit_checker.py
+++ b/pipeline/commit_checker.py
@@ -121,6 +121,10 @@ def main():
     pr_body = sys.argv[3]
     head_sha = sys.argv[4]
 
+    if branch_name == "develop":
+        print("Branch is 'develop', skipping commit checks.")
+        sys.exit(0)
+
     print(f"Branch name: {branch_name}")
     print(f"PR title: {pr_title}")
     print(f"Head commit SHA: {head_sha}")


### PR DESCRIPTION
This change fix the issue with checking conventional commits on develop just simply skipping them. We already merging whole story to the main, so this is pointless check.

Issue-ID: gh-79