### PR TITLE
Fix: GitHub Pages wrong version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,44 +2,44 @@ name: Generate Docs
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
     paths:
-      - "app/**"
+    - "app/**"
   pull_request:
-      types: [ opened, edited, reopened, synchronize ]
-      branches: [main]
-      paths:
-        - "app/**"
+    types: [ opened, edited, reopened, synchronize ]
+    branches: [ main ]
+    paths:
+    - "app/**"
   workflow_dispatch:
+
 
 permissions:
   contents: write
- 
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+    - name: Checkout repository
+      uses: actions/checkout@v6
 
-      - name: Install Doxygen
-        run:
-          sudo apt-get update && sudo apt-get install -y doxygen graphviz
+    - name: Install Doxygen
+      run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
 
-      - name: Generate documentation
-        run: |
-          cd docs
-          doxygen Doxyfile
+    - name: Generate documentation
+      run: |
+        cd docs
+        doxygen Doxyfile
 
-      - name: Upload documentation artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: documentation
-          path: docs/html
+    - name: Upload documentation artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: documentation
+        path: docs/html
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v6
-        with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            publish_dir: docs/html
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/html


### PR DESCRIPTION
This change fix the issue with the wrong (v6) version of the Github Actions responsible for deploying docs to GH Pages.

Issue-ID: gh-81