### PR TITLE
feat: add aws secrets manager with eso

### DIFF
--- a/.github/workflows/terraform_env_dev.yml
+++ b/.github/workflows/terraform_env_dev.yml
@@ -26,6 +26,12 @@ jobs:
   terraform-env-dev:
     runs-on: ubuntu-latest
 
+    env:
+      TF_VAR_db_user: ${{ secrets.TF_VAR_DB_USER }}
+      TF_VAR_db_password: ${{ secrets.TF_VAR_DB_PASSWORD }}
+      TF_VAR_db_name: ${{ secrets.TF_VAR_DB_NAME }}
+      TF_VAR_app_secret_key: ${{ secrets.TF_VAR_APP_SECRET_KEY }}
+
     defaults:
       run:
         working-directory: infra/terraform/environments/dev

--- a/infra/k8s/eso/README.md
+++ b/infra/k8s/eso/README.md
@@ -1,0 +1,107 @@
+# External Secrets Operator
+
+External Secrets Operator (ESO) syncs secrets from AWS Secrets Manager into Kubernetes Secrets. Instead of storing credentials in K8s (where they are only base64-encoded, not encrypted), secrets live in Secrets Manager and ESO pulls them on a regular interval via IRSA.
+
+## How it works
+
+```
+AWS Secrets Manager          Kubernetes
+  boardgames-dev-db    →  Secret: db-credentials
+  boardgames-dev-app   →  Secret: app-credentials
+        ↑
+   IRSA role (boardgames-dev-irsa-role)
+   ServiceAccount: external-secrets-sa
+```
+
+1. The ESO pod uses a ServiceAccount annotated with IRSA → receives temporary AWS credentials
+2. `SecretStore` defines where to fetch secrets (Secrets Manager, region eu-central-1)
+3. `ExternalSecret` maps specific keys from Secrets Manager to a K8s Secret
+4. Sync every 1 hour — changes in Secrets Manager propagate to K8s automatically
+
+## Prerequisites
+
+- EKS cluster with OIDC provider (`infra/terraform/modules/eks`)
+- Secrets created in AWS Secrets Manager (`infra/terraform/modules/secrets`)
+- IRSA role `boardgames-dev-irsa-role` with `secretsmanager:GetSecretValue` permission
+- `kubectl` configured for the EKS cluster
+
+## Install ESO
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+
+helm install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace \
+  --set installCRDs=true
+
+# Verify ESO is running
+kubectl get pods -n external-secrets
+```
+
+## Apply manifests
+
+```bash
+# ServiceAccount with IRSA annotation
+kubectl apply -f infra/k8s/eso/service-account.yaml
+
+# SecretStore — connection to AWS Secrets Manager
+kubectl apply -f infra/k8s/eso/secret-store.yaml
+
+# ExternalSecret — secret mapping
+kubectl apply -f infra/k8s/eso/external-secrets.yaml
+```
+
+## Verify sync
+
+```bash
+# Check sync status (should show Ready=True)
+kubectl get externalsecret -n boardgames
+
+# Describe for troubleshooting
+kubectl describe externalsecret db-credentials -n boardgames
+
+# Verify K8s Secrets were created
+kubectl get secret db-credentials -n boardgames
+kubectl get secret app-credentials -n boardgames
+
+# Inspect values (base64-decoded)
+kubectl get secret db-credentials -n boardgames -o jsonpath='{.data.DATABASE_URL}' | base64 -d
+```
+
+## File overview
+
+| File | Purpose |
+|---|---|
+| `service-account.yaml` | ServiceAccount with IRSA annotation (`eks.amazonaws.com/role-arn`) |
+| `secret-store.yaml` | SecretStore pointing to AWS Secrets Manager in eu-central-1 |
+| `external-secrets.yaml` | Two ExternalSecrets: `db-credentials` and `app-credentials` |
+
+## Secrets in AWS Secrets Manager
+
+| Secret name | Keys | Synced to K8s Secret |
+|---|---|---|
+| `boardgames-dev-db` | `user`, `password`, `dbname`, `url` | `db-credentials` |
+| `boardgames-dev-app` | `secret_key` | `app-credentials` |
+
+## Updating secrets
+
+To rotate credentials:
+
+```bash
+# Via AWS CLI
+aws secretsmanager put-secret-value \
+  --secret-id boardgames-dev-db \
+  --secret-string '{"user":"boardgames","password":"new_password","dbname":"boardgames","url":"postgresql://boardgames:new_password@db-service:5432/boardgames"}'
+
+# Via Terraform (re-apply with updated variable value)
+# TF_VAR_db_password=new_password terraform apply
+
+# ESO picks up the new value on the next sync (up to 1h)
+# To force immediate sync:
+kubectl annotate externalsecret db-credentials \
+  force-sync=$(date +%s) \
+  --overwrite \
+  -n boardgames
+```

--- a/infra/k8s/eso/README.md
+++ b/infra/k8s/eso/README.md
@@ -42,6 +42,13 @@ kubectl get pods -n external-secrets
 
 ## Apply manifests
 
+> **Note:** `service-account.yaml` contains an `<ACCOUNT_ID>` placeholder. Before applying, fetch
+> the ARN from Terraform and render with envsubst:
+> ```bash
+> export IRSA_ROLE_ARN=$(terraform -chdir=infra/terraform/environments/dev output -raw irsa_role_arn)
+> envsubst < infra/k8s/eso/service-account.yaml | kubectl apply -f -
+> ```
+
 ```bash
 # ServiceAccount with IRSA annotation
 kubectl apply -f infra/k8s/eso/service-account.yaml

--- a/infra/k8s/eso/external-secrets.yaml
+++ b/infra/k8s/eso/external-secrets.yaml
@@ -1,0 +1,49 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: db-credentials
+  namespace: boardgames
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: SecretStore
+  target:
+    name: db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: POSTGRES_USER
+      remoteRef:
+        key: boardgames-dev-db
+        property: user
+    - secretKey: POSTGRES_PASSWORD
+      remoteRef:
+        key: boardgames-dev-db
+        property: password
+    - secretKey: POSTGRES_DB
+      remoteRef:
+        key: boardgames-dev-db
+        property: dbname
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: boardgames-dev-db
+        property: url
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-credentials
+  namespace: boardgames
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: SecretStore
+  target:
+    name: app-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: SECRET_KEY
+      remoteRef:
+        key: boardgames-dev-app
+        property: secret_key

--- a/infra/k8s/eso/secret-store.yaml
+++ b/infra/k8s/eso/secret-store.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secrets-manager
+  namespace: boardgames
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: eu-central-1
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa

--- a/infra/k8s/eso/service-account.yaml
+++ b/infra/k8s/eso/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-sa
+  namespace: boardgames
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::595324333130:role/boardgames-dev-irsa-role

--- a/infra/k8s/eso/service-account.yaml
+++ b/infra/k8s/eso/service-account.yaml
@@ -4,4 +4,7 @@ metadata:
   name: external-secrets-sa
   namespace: boardgames
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::595324333130:role/boardgames-dev-irsa-role
+    # Apply via envsubst — do not apply this file directly:
+    # export IRSA_ROLE_ARN=$(terraform -chdir=infra/terraform/environments/dev output -raw irsa_role_arn)
+    # envsubst < service-account.yaml | kubectl apply -f -
+    eks.amazonaws.com/role-arn: ${IRSA_ROLE_ARN}

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -23,3 +23,15 @@ module "eks" {
   public_subnet_ids   = module.networking.public_subnet_ids
   ecr_repository_arns = values(module.ecr.repository_arns)
 }
+
+module "secrets" {
+  source = "../../modules/secrets"
+
+  project     = "boardgames"
+  environment = "dev"
+
+  db_user        = var.db_user
+  db_password    = var.db_password
+  db_name        = var.db_name
+  app_secret_key = var.app_secret_key
+}

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -1,0 +1,4 @@
+output "irsa_role_arn" {
+  description = "ARN of the IRSA role — use when applying infra/k8s/eso/service-account.yaml"
+  value       = module.eks.irsa_role_arn
+}

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -1,0 +1,23 @@
+variable "db_user" {
+  description = "PostgreSQL username"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password" {
+  description = "PostgreSQL password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  sensitive   = true
+}
+
+variable "app_secret_key" {
+  description = "Django SECRET_KEY"
+  type        = string
+  sensitive   = true
+}

--- a/infra/terraform/modules/secrets/locals.tf
+++ b/infra/terraform/modules/secrets/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+
+  common_tags = {
+    Project     = var.project
+    Environment = var.environment
+    Component   = var.component
+    ManagedBy   = "Terraform"
+  }
+
+  db_url = "postgresql://${var.db_user}:${var.db_password}@db-service:5432/${var.db_name}"
+}

--- a/infra/terraform/modules/secrets/main.tf
+++ b/infra/terraform/modules/secrets/main.tf
@@ -1,8 +1,30 @@
+data "aws_caller_identity" "current" {}
+
+# --- KMS Key ---
+
+resource "aws_kms_key" "secrets" {
+  description             = "KMS key for ${local.name_prefix} Secrets Manager encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy = templatefile("${path.module}/policies/secrets-kms-policy.json.tftpl", {
+    account_id = data.aws_caller_identity.current.account_id
+  })
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-secrets-kms" })
+}
+
+resource "aws_kms_alias" "secrets" {
+  name          = "alias/${local.name_prefix}-secrets"
+  target_key_id = aws_kms_key.secrets.key_id
+}
+
 # --- DB Secret ---
 
 resource "aws_secretsmanager_secret" "db" {
+  #checkov:skip=CKV2_AWS_57: Automatic rotation requires Lambda-based rotator coordinating with the database — out of scope for PoC
   name        = "${local.name_prefix}-db"
   description = "PostgreSQL credentials for ${local.name_prefix} application"
+  kms_key_id  = aws_kms_key.secrets.arn
 
   tags = merge(local.common_tags, { Name = "${local.name_prefix}-db" })
 }
@@ -20,8 +42,10 @@ resource "aws_secretsmanager_secret_version" "db" {
 # --- App Secret ---
 
 resource "aws_secretsmanager_secret" "app" {
+  #checkov:skip=CKV2_AWS_57: Automatic rotation requires Lambda-based rotator — out of scope for PoC
   name        = "${local.name_prefix}-app"
   description = "Application secrets for ${local.name_prefix}"
+  kms_key_id  = aws_kms_key.secrets.arn
 
   tags = merge(local.common_tags, { Name = "${local.name_prefix}-app" })
 }

--- a/infra/terraform/modules/secrets/main.tf
+++ b/infra/terraform/modules/secrets/main.tf
@@ -1,0 +1,34 @@
+# --- DB Secret ---
+
+resource "aws_secretsmanager_secret" "db" {
+  name        = "${local.name_prefix}-db"
+  description = "PostgreSQL credentials for ${local.name_prefix} application"
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-db" })
+}
+
+resource "aws_secretsmanager_secret_version" "db" {
+  secret_id = aws_secretsmanager_secret.db.id
+  secret_string = jsonencode({
+    user     = var.db_user
+    password = var.db_password
+    dbname   = var.db_name
+    url      = local.db_url
+  })
+}
+
+# --- App Secret ---
+
+resource "aws_secretsmanager_secret" "app" {
+  name        = "${local.name_prefix}-app"
+  description = "Application secrets for ${local.name_prefix}"
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-app" })
+}
+
+resource "aws_secretsmanager_secret_version" "app" {
+  secret_id = aws_secretsmanager_secret.app.id
+  secret_string = jsonencode({
+    secret_key = var.app_secret_key
+  })
+}

--- a/infra/terraform/modules/secrets/outputs.tf
+++ b/infra/terraform/modules/secrets/outputs.tf
@@ -7,3 +7,8 @@ output "app_secret_arn" {
   description = "ARN of the application secret"
   value       = aws_secretsmanager_secret.app.arn
 }
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for Secrets Manager encryption"
+  value       = aws_kms_key.secrets.arn
+}

--- a/infra/terraform/modules/secrets/outputs.tf
+++ b/infra/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,9 @@
+output "db_secret_arn" {
+  description = "ARN of the database credentials secret"
+  value       = aws_secretsmanager_secret.db.arn
+}
+
+output "app_secret_arn" {
+  description = "ARN of the application secret"
+  value       = aws_secretsmanager_secret.app.arn
+}

--- a/infra/terraform/modules/secrets/policies/secrets-kms-policy.json.tftpl
+++ b/infra/terraform/modules/secrets/policies/secrets-kms-policy.json.tftpl
@@ -1,0 +1,26 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EnableRootAccess",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${account_id}:root"
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "AllowSecretsManager",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "secretsmanager.amazonaws.com"
+      },
+      "Action": [
+        "kms:GenerateDataKey",
+        "kms:Decrypt"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/infra/terraform/modules/secrets/providers.tf
+++ b/infra/terraform/modules/secrets/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/infra/terraform/modules/secrets/variables.tf
+++ b/infra/terraform/modules/secrets/variables.tf
@@ -1,0 +1,47 @@
+variable "project" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "boardgames"
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+  default     = "dev"
+}
+
+variable "component" {
+  description = "Component name used for tagging"
+  type        = string
+  default     = "secrets"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "db_user" {
+  description = "PostgreSQL username"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_password" {
+  description = "PostgreSQL password"
+  type        = string
+  sensitive   = true
+}
+
+variable "db_name" {
+  description = "PostgreSQL database name"
+  type        = string
+  sensitive   = true
+}
+
+variable "app_secret_key" {
+  description = "Django SECRET_KEY"
+  type        = string
+  sensitive   = true
+}

--- a/infra/terraform/modules/secrets/versions.tf
+++ b/infra/terraform/modules/secrets/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">=1.9.0, <2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
@@ -240,6 +240,25 @@
         "logs:ListTagsForResource"
       ],
       "Resource": "arn:aws:logs:eu-central-1:${account_id}:log-group:/aws/eks/boardgames-${environment}-eks/*"
+    },
+    {
+      "Sid": "ManageSecretsManager",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:TagResource",
+        "secretsmanager:UntagResource",
+        "secretsmanager:ListSecretVersionIds",
+        "secretsmanager:GetResourcePolicy",
+        "secretsmanager:PutResourcePolicy",
+        "secretsmanager:DeleteResourcePolicy"
+      ],
+      "Resource": "arn:aws:secretsmanager:eu-central-1:${account_id}:secret:boardgames-${environment}-*"
     }
   ]
 }

--- a/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
@@ -259,6 +259,48 @@
         "secretsmanager:DeleteResourcePolicy"
       ],
       "Resource": "arn:aws:secretsmanager:eu-central-1:${account_id}:secret:boardgames-${environment}-*"
+    },
+    {
+      "Sid": "CreateKmsKey",
+      "Effect": "Allow",
+      "Action": "kms:CreateKey",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/Project": "boardgames"
+        }
+      }
+    },
+    {
+      "Sid": "ManageKmsKeys",
+      "Effect": "Allow",
+      "Action": [
+        "kms:DescribeKey",
+        "kms:GetKeyPolicy",
+        "kms:GetKeyRotationStatus",
+        "kms:ListResourceTags",
+        "kms:PutKeyPolicy",
+        "kms:ScheduleKeyDeletion",
+        "kms:CancelKeyDeletion",
+        "kms:EnableKeyRotation",
+        "kms:DisableKeyRotation",
+        "kms:TagResource",
+        "kms:UntagResource"
+      ],
+      "Resource": "arn:aws:kms:eu-central-1:${account_id}:key/*"
+    },
+    {
+      "Sid": "ManageKmsAliases",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateAlias",
+        "kms:DeleteAlias",
+        "kms:ListAliases"
+      ],
+      "Resource": [
+        "arn:aws:kms:eu-central-1:${account_id}:alias/boardgames-${environment}-*",
+        "arn:aws:kms:eu-central-1:${account_id}:key/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This change introduces module responsible for handling secrets for our app - db and django. There is AWS Secrets Manager and External Secrets Operator in terraform. The only step required is with started infra on AWS - installation them via Helm on the EKS.

Issue-ID: gh-72