### PR TITLE
feat: add EBS persistent storage for PostgreSQL database

### DIFF
--- a/infra/k8s/README.md
+++ b/infra/k8s/README.md
@@ -1,0 +1,88 @@
+# Persistent Storage for PostgreSQL
+
+Replaces the `emptyDir` volume on the `db` Deployment with a PersistentVolumeClaim
+backed by AWS EBS gp3. Data now survives pod restarts, rescheduling, and node replacement.
+
+## How it works
+
+```
+StorageClass (gp3)
+  └── PersistentVolumeClaim (db-storage, 5Gi)
+        └── Deployment (db) mounts at /var/lib/postgresql/data
+              └── EBS CSI driver provisions gp3 EBS volume
+```
+
+1. `StorageClass` tells Kubernetes to use the EBS CSI driver with gp3 volume type
+2. `PersistentVolumeClaim` requests 5Gi of storage
+3. The `db` Deployment mounts the PVC instead of an `emptyDir`
+4. EBS CSI driver (EKS add-on) dynamically provisions an EBS volume on first pod schedule
+
+## Prerequisites
+
+- EKS cluster with the `aws-ebs-csi-driver` add-on (provisioned by `infra/terraform/modules/eks`)
+- EKS node role with `AmazonEBSCSIDriverPolicy` attached
+- `kubectl` configured for the EKS cluster
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `storage-class.yaml` | gp3 StorageClass — EBS CSI provisioner, Retain policy, WaitForFirstConsumer |
+| `db-pvc.yaml` | 5Gi PVC in `boardgames` namespace |
+| `db-deployment.yaml` | Updated — `db-storage` volume uses PVC instead of emptyDir |
+
+## Apply
+
+```bash
+kubectl apply -f infra/k8s/storage-class.yaml
+kubectl apply -f infra/k8s/db-pvc.yaml
+kubectl apply -f infra/k8s/db-deployment.yaml
+```
+
+## Verify
+
+```bash
+# PVC should show Bound status
+kubectl get pvc -n boardgames
+
+# EBS volume should be visible
+kubectl get pv
+
+# Test data persistence
+kubectl exec -n boardgames deploy/db -- psql -U postgres -c "CREATE TABLE persist_test(id int);"
+kubectl rollout restart deployment/db -n boardgames
+kubectl wait --for=condition=ready pod -l app=db -n boardgames --timeout=60s
+kubectl exec -n boardgames deploy/db -- psql -U postgres -c "SELECT tablename FROM pg_tables WHERE tablename='persist_test';"
+# Should return: persist_test
+```
+
+## StorageClass details
+
+| Setting | Value | Why |
+|---|---|---|
+| `provisioner` | `ebs.csi.aws.com` | EKS-native EBS CSI driver |
+| `type` | `gp3` | Better baseline IOPS/throughput than gp2, same cost |
+| `reclaimPolicy` | `Retain` | EBS volume preserved after PVC deletion — prevents accidental data loss |
+| `volumeBindingMode` | `WaitForFirstConsumer` | Volume created in the same AZ as the pod — avoids cross-AZ mount failures |
+| `allowVolumeExpansion` | `true` | PVC can be resized without recreating |
+
+## Expanding storage
+
+```bash
+kubectl patch pvc db-storage -n boardgames -p '{"spec":{"resources":{"requests":{"storage":"10Gi"}}}}'
+# Pod restart required for filesystem resize
+kubectl rollout restart deployment/db -n boardgames
+```
+
+## Cleanup
+
+Deleting the PVC does **not** delete the EBS volume (`reclaimPolicy: Retain`).
+To fully clean up:
+
+```bash
+kubectl delete -f infra/k8s/db-pvc.yaml
+# Then manually delete the Released PV and EBS volume
+kubectl get pv  # find the Released PV
+kubectl delete pv <pv-name>
+# Delete EBS volume from AWS console or CLI
+```

--- a/infra/k8s/db-deployment.yaml
+++ b/infra/k8s/db-deployment.yaml
@@ -83,7 +83,8 @@ spec:
               mountPath: /var/run/postgresql
       volumes:
         - name: db-storage
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: db-storage
         - name: tmp
           emptyDir: {}
         - name: run-postgresql

--- a/infra/k8s/db-pvc.yaml
+++ b/infra/k8s/db-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-storage
+  namespace: boardgames
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp3
+  resources:
+    requests:
+      storage: 5Gi

--- a/infra/k8s/storage-class.yaml
+++ b/infra/k8s/storage-class.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gp3
+provisioner: ebs.csi.aws.com
+parameters:
+  type: gp3
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/infra/terraform/modules/eks/README.md
+++ b/infra/terraform/modules/eks/README.md
@@ -38,13 +38,14 @@ modules/eks/
 | `aws_iam_openid_connect_provider` | 1 | OIDC for IRSA |
 | `aws_iam_role` | 3 | cluster-role, node-role, irsa-role |
 | `aws_iam_policy` | 1 | IRSA permissions (ECR pull, Secrets Manager) |
-| `aws_iam_role_policy_attachment` | 5 | AWS managed + custom policies |
+| `aws_iam_role_policy_attachment` | 6 | AWS managed + custom policies |
 | `aws_security_group` | 2 | Control plane, nodes |
 | `aws_security_group_rule` | 4 | Egress, node↔cluster, node↔node |
 | `aws_eks_access_entry` | 1 | Platform role → cluster admin |
 | `aws_eks_access_policy_association` | 1 | AmazonEKSClusterAdminPolicy |
+| `aws_eks_addon` | 1 | EBS CSI driver for persistent volumes |
 
-Total: **20 resources**
+Total: **22 resources**
 
 ## Security groups
 
@@ -56,7 +57,7 @@ Total: **20 resources**
 | Role | Trust | Policies |
 |---|---|---|
 | `eks-cluster-role` | `eks.amazonaws.com` | AmazonEKSClusterPolicy |
-| `eks-node-role` | `ec2.amazonaws.com` | AmazonEKSWorkerNodePolicy, AmazonEKS_CNI_Policy, AmazonEC2ContainerRegistryReadOnly |
+| `eks-node-role` | `ec2.amazonaws.com` | AmazonEKSWorkerNodePolicy, AmazonEKS_CNI_Policy, AmazonEC2ContainerRegistryReadOnly, AmazonEBSCSIDriverPolicy |
 | `irsa-role` | OIDC federation | ECR pull, Secrets Manager read (scoped to `boardgames-dev-*`) |
 
 ## Usage

--- a/infra/terraform/modules/eks/iam.tf
+++ b/infra/terraform/modules/eks/iam.tf
@@ -38,6 +38,11 @@ resource "aws_iam_role_policy_attachment" "node_ecr" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
+resource "aws_iam_role_policy_attachment" "node_ebs_csi" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
 # --- IRSA Role ---
 
 resource "aws_iam_role" "irsa" {

--- a/infra/terraform/modules/eks/main.tf
+++ b/infra/terraform/modules/eks/main.tf
@@ -127,8 +127,9 @@ resource "aws_eks_node_group" "main" {
 # --- EBS CSI Driver Add-on ---
 
 resource "aws_eks_addon" "ebs_csi" {
-  cluster_name = aws_eks_cluster.main.name
-  addon_name   = "aws-ebs-csi-driver"
+  cluster_name  = aws_eks_cluster.main.name
+  addon_name    = "aws-ebs-csi-driver"
+  addon_version = "v1.38.1-eksbuild.1"
 
   depends_on = [aws_eks_node_group.main]
 

--- a/infra/terraform/modules/eks/main.tf
+++ b/infra/terraform/modules/eks/main.tf
@@ -118,9 +118,21 @@ resource "aws_eks_node_group" "main" {
     aws_iam_role_policy_attachment.node_worker,
     aws_iam_role_policy_attachment.node_cni,
     aws_iam_role_policy_attachment.node_ecr,
+    aws_iam_role_policy_attachment.node_ebs_csi,
   ]
 
   tags = { Name = "${local.name_prefix}-eks-nodes" }
+}
+
+# --- EBS CSI Driver Add-on ---
+
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name = aws_eks_cluster.main.name
+  addon_name   = "aws-ebs-csi-driver"
+
+  depends_on = [aws_eks_node_group.main]
+
+  tags = { Name = "${local.name_prefix}-ebs-csi" }
 }
 
 # --- OIDC Provider (for IRSA) ---

--- a/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
+++ b/infra/terraform/platform/bootstrap/platform-bootstrap-policy.json.tftpl
@@ -154,7 +154,12 @@
         "eks:DescribeAccessEntry",
         "eks:AssociateAccessPolicy",
         "eks:DisassociateAccessPolicy",
-        "eks:ListAssociatedAccessPolicies"
+        "eks:ListAssociatedAccessPolicies",
+        "eks:CreateAddon",
+        "eks:DeleteAddon",
+        "eks:DescribeAddon",
+        "eks:DescribeAddonVersions",
+        "eks:UpdateAddon"
       ],
       "Resource": [
         "arn:aws:eks:eu-central-1:${account_id}:cluster/boardgames-${environment}-eks",


### PR DESCRIPTION
Replace emptyDir with gp3 PersistentVolumeClaim for db Deployment.
Add EBS CSI driver as EKS add-on with AmazonEBSCSIDriverPolicy on
node role. Add StorageClass, PVC, and K8s README. Extend bootstrap
policy with EKS add-on management permissions.

Issue-ID: gh-89
