### PR TITLE
fix: rework workflows responsible for deploying app

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,9 +1,16 @@
 name: Build and Push to ECR
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (leave empty for HEAD of main)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   id-token: write
@@ -16,6 +23,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.inputs.ref || github.sha }}
+
+    - name: Get image tag
+      id: tag
+      run: echo "tag=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v6
@@ -33,15 +46,15 @@ jobs:
       run: |
         docker build \
           -f infra/docker/backend.Dockerfile \
-          -t ${{ vars.ECR_REGISTRY }}/boardgames-dev/backend:${{ github.sha }} \
+          -t ${{ vars.ECR_REGISTRY }}/boardgames-dev/backend:${{ steps.tag.outputs.tag }} \
           .
-        docker push ${{ vars.ECR_REGISTRY }}/boardgames-dev/backend:${{ github.sha }}
+        docker push ${{ vars.ECR_REGISTRY }}/boardgames-dev/backend:${{ steps.tag.outputs.tag }}
 
     - name: Build and push frontend
       run: |
         docker build \
           -f infra/docker/frontend.Dockerfile \
           --build-arg VITE_API_URL="" \
-          -t ${{ vars.ECR_REGISTRY }}/boardgames-dev/frontend:${{ github.sha }} \
+          -t ${{ vars.ECR_REGISTRY }}/boardgames-dev/frontend:${{ steps.tag.outputs.tag }} \
           .
-        docker push ${{ vars.ECR_REGISTRY }}/boardgames-dev/frontend:${{ github.sha }}
+        docker push ${{ vars.ECR_REGISTRY }}/boardgames-dev/frontend:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/deploy_eks.yml
+++ b/.github/workflows/deploy_eks.yml
@@ -1,12 +1,16 @@
 name: Deploy to EKS
 
 on:
-  workflow_run:
-    workflows: ["Build and Push to ECR"]
-    types:
-      - completed
+  push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag (commit SHA) to deploy (leave empty for latest commit on main)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   id-token: write
@@ -15,10 +19,8 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
     env:
-      IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+      IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This change introduces rework for build_and_push and deploy_eks workflows. Now the first one works on every PR into main and there is possibility to run it manually. The second one works on push into main, and manually.

Issue-ID: gh-88